### PR TITLE
Move arg parsing as separate file and refactor the instantiation; add tests

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,5 +6,6 @@
         "code"
     ],
     "python.testing.unittestEnabled": false,
-    "python.testing.pytestEnabled": true
+    "python.testing.pytestEnabled": true,
+    "python.formatting.provider": "black"
 }

--- a/code/__init__.py
+++ b/code/__init__.py
@@ -1,26 +1,3 @@
-
 import sys
+
 print(sys.argv)
-the={}
-if len(sys.argv)>1:
-    param=sys.argv[1]
-    if param=="-e":
-        the["e"]="nothing"
-    elif param=="-d":
-        the["d"]=False
-    elif param=="-f":
-        the["f"]=sys.argv[2]
-    elif param=="-h":
-        the["h"]=False
-    elif param=="-n":
-        the["n"]=512
-        if len(sys.argv)>2:
-            the["n"]=sys.argv[2]
-    elif param=="-s":
-        the["s"]=10019
-    elif param=="-S":
-        the["S"]=","
-        if len(sys.argv)>2:
-            the["n"]=sys.argv[2]
-
-

--- a/code/args.py
+++ b/code/args.py
@@ -1,0 +1,33 @@
+import sys
+
+class The:
+  def __init__(self):
+    self.the = {
+      "e": "nothing",
+      "d": False,
+      "f": "../test/sample.csv",
+      "h": False,
+      "n": 512,
+      "s": 10019,
+      "S": ","
+    }
+    if len(sys.argv) > 1:
+      param = sys.argv[1]
+      if param == "-e":
+          self.the["e"] = sys.argv[2]
+      elif param == "-d":
+          self.the["d"] = sys.argv[2]
+      elif param == "-f":
+          self.the["f"] = sys.argv[2]
+      elif param == "-h":
+          self.the["h"] = sys.argv[2]
+      elif param == "-n":
+          self.the["n"] = 512
+          if len(sys.argv) > 2:
+              self.the["n"] = sys.argv[2]
+      elif param == "-s":
+          self.the["s"] = 10019
+      elif param == "-S":
+          self.the["S"] = ","
+          if len(sys.argv) > 2:
+              self.the["S"] = sys.argv[2]

--- a/test/test_the.py
+++ b/test/test_the.py
@@ -1,0 +1,17 @@
+from args import The
+from print import oo
+
+
+class TestThe():
+  def test_the(self):
+    self.params = The()
+
+    oo(self.params.the)
+
+    assert self.params.the["e"] == "nothing"
+    assert not self.params.the["d"]
+    assert self.params.the["f"] == "../test/sample.csv"
+    assert self.params.the["h"] == False
+    assert self.params.the["n"] == 512
+    assert self.params.the["s"] == 10019
+    assert self.params.the["S"] == ","


### PR DESCRIPTION
Some major refactoring for the `the` logic of the program. Decided to move out the `the` functionality to its own class so it can be more easily tested. init.py will essentially bring in all the necessary imports and then do the last 4 lines in csv.lua.